### PR TITLE
feat: make default workflow domain configurable at runtime

### DIFF
--- a/.vibe/development-plan-refactor-configurable-default-domain.md
+++ b/.vibe/development-plan-refactor-configurable-default-domain.md
@@ -471,12 +471,26 @@ private getActiveWorkflow(): WorkflowInfo | null {
 ## Commit
 
 ### Tasks
-- [ ] Commit with conventional commit message
-- [ ] Push branch
+- [x] Commit with conventional commit message
+- [x] Push branch
+- [x] Create pull request
 
 ### Completed
-*None yet*
+- [x] Committed as `1999cd7` on `refactor/configurable-default-domain`
+- [x] PR: https://github.com/codemcp/workflows/pull/281
 
+### Domain Descriptions (improved)
+Domain descriptions were refined to summarize what each domain is suitable for, based on reading all 24 workflow YAML files:
+
+| Domain | Description |
+|--------|-------------|
+| `code` | Day-to-day software engineering (features, TDD, bugfixes, greenfield, code reviews) |
+| `architecture` | System understanding and planning (architectural decisions, legacy modernization, capability modeling) |
+| `sdd` | Specification-driven development — write detailed specs before coding |
+| `sdd-crowd` | Multi-agent collaborative SDD with role-based handoffs (analyst, architect, developer) |
+| `skilled` | Skill-augmented development — explicit prompts to apply expertise (architecture, coding, testing) |
+| `office` | Content creation and communication (blog posts, slide presentations) |
+| `children` | Educational game development for ages 8-12 |
 
 ---
 *This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/.vibe/development-plan-refactor-configurable-default-domain.md
+++ b/.vibe/development-plan-refactor-configurable-default-domain.md
@@ -466,7 +466,7 @@ private getActiveWorkflow(): WorkflowInfo | null {
 - **Empty Set fallback**: When no domain config is set, ALL workflows load (no filtering). This is the expected behavior for users who don't configure domain filtering.
 - **`getActiveWorkflow()` returns null**: The actual active workflow detection is handled by `ConversationManager`. The guard in `setDomains()` is a placeholder for future integration.
 - **`loadPredefinedWorkflows()` now clears maps**: This was a pre-existing bug that became visible when `setDomains()` called `loadPredefinedWorkflows()`. Old workflows would accumulate across domain switches.
-- **Domain descriptions in tool parameters**: Both MCP server and OpenCode plugin embed the full domain descriptions in the tool's parameter schema, allowing the LLM to discover and choose domains intelligently.
+- **Domain descriptions as resource**: Domain descriptions are exposed via `domain://` resource (MCP server) rather than embedded in the tool parameter. This keeps the `load_workflows` tool schema lean and reduces LLM context usage. The LLM queries the resource to discover domains before calling the tool. OpenCode plugin uses a simple enum with inline domain list in the description.
 
 ## Commit
 
@@ -476,7 +476,8 @@ private getActiveWorkflow(): WorkflowInfo | null {
 - [x] Create pull request
 
 ### Completed
-- [x] Committed as `1999cd7` on `refactor/configurable-default-domain`
+- [x] Initial commit `1999cd7`: feat — configurable default domain
+- [x] Follow-up commit `80dcf69`: refactor — move domain descriptions from tool parameter to resource
 - [x] PR: https://github.com/codemcp/workflows/pull/281
 
 ### Domain Descriptions (improved)

--- a/.vibe/development-plan-refactor-configurable-default-domain.md
+++ b/.vibe/development-plan-refactor-configurable-default-domain.md
@@ -1,0 +1,482 @@
+# Development Plan: Refactor Configurable Default Domain
+
+*Generated on 2026-05-22 by Vibe Feature MCP*
+*Workflow: [epcc](https://codemcp.github.io/workflows/workflows/epcc)*
+*Branch: refactor/configurable-default-domain*
+
+## Goal
+
+Make the default workflow domain configurable at runtime by:
+1. Eliminating hardcoded `'code'` defaults in `WorkflowManager` (env vars + constructor params)
+2. Providing a `load_workflows(domains)` tool for the LLM to dynamically load domains in long-lived processes (MCP server, OpenCode plugin)
+
+## Key Decisions
+
+### 1. Environment variable approach (process-level config)
+
+Add `DEFAULT_DOMAINS` env var as the fallback when `WORKFLOW_DOMAINS` is unset. This allows users to set a default in their shell profile without code changes.
+
+### 2. Constructor parameter (programmatic override)
+
+Add `defaultDomains?: string | string[]` to the `WorkflowManager` constructor for library consumers and testing.
+
+### 3. `load_workflows(domains)` tool (runtime switching)
+
+A dedicated MCP tool that lets the LLM hot-reload workflows from any domain without restarting the process. The tool's parameter description includes hard-coded descriptions for each known domain, so the LLM can discover and choose intelligently.
+
+**`start_development` is NOT modified** — it stays as-is. The LLM must explicitly call `load_workflows` before `start_development` if the target workflow is in a domain not currently loaded.
+
+### 4. Backward compatibility
+
+Keep `VIBE_WORKFLOW_DOMAINS` as a legacy alias. The precedence chain is: constructor param > `WORKFLOW_DOMAINS` > `DEFAULT_DOMAINS` > `VIBE_WORKFLOW_DOMAINS` > empty Set (no filtering).
+
+### 5. Two separate concerns
+
+The default domain (`parseEnabledDomains`) and the "all domains" list (`getAllAvailableWorkflows`) are separate. We address both independently.
+
+## Notes
+
+### Current State
+
+The `WorkflowManager` in `packages/core/src/workflow-manager.ts` has two hardcoded domain values:
+
+1. **Line 64**: Default fallback is `Set(['code'])` when no env var is set:
+   ```typescript
+   if (!domainsEnv) {
+     logger.debug('No domain configuration found, using default: code');
+     return new Set(['code']);
+   }
+   ```
+
+2. **Line 191**: `getAllAvailableWorkflows()` hardcodes all known domains:
+   ```typescript
+   process.env['WORKFLOW_DOMAINS'] = 'code,architecture,office,sdd';
+   ```
+
+### Known Domains in the Wild
+
+From scanning all 25 workflow YAML files:
+| Domain | Count | Examples |
+|--------|-------|---------|
+| `code` | 9 | epcc, tdd, bugfix, minor, greenfield, waterfall, pr-review |
+| `architecture` | 5 | adr, big-bang-conversion, boundary-testing, business-analysis, c4-analysis |
+| `sdd` | 3 | sdd-bugfix, sdd-feature, sdd-greenfield |
+| `sdd-crowd` | 3 | sdd-bugfix-crowd, sdd-feature-crowd, sdd-greenfield-crowd |
+| `skilled` | 3 | skilled-bugfix, skilled-epcc, skilled-greenfield |
+| `office` | 2 | posts, slides |
+| `children` | 1 | game-beginner |
+
+### Existing Environment Variables
+
+| Variable | Purpose | Current Use |
+|----------|---------|-------------|
+| `WORKFLOW_DOMAINS` | Canonical: comma-separated list of enabled domains | Controls which domains are active |
+| `VIBE_WORKFLOW_DOMAINS` | Legacy alias for `WORKFLOW_DOMAINS` | Backward compatibility |
+
+### Affected Files
+
+1. `packages/core/src/workflow-manager.ts` — Core domain parsing logic + `setDomains()` method
+2. `packages/mcp-server/src/server-config.ts` — Register `load_workflows` tool
+3. `packages/opencode-plugin/src/tool-handlers/` — Register `load_workflows` tool
+4. `packages/core/test/unit/workflow-domains-precedence.test.ts` — Existing domain tests
+5. `packages/core/test/unit/workflow-domain-switching.test.ts` — New tests for `setDomains()`
+
+### Usage Sites
+
+- `parseEnabledDomains()` is called in the constructor — affects all WorkflowManager instances
+- `getAllAvailableWorkflows()` is called by `packages/cli/src/cli.ts` for the `workflow copy` command
+- `load_workflows()` is a new tool available in MCP server and OpenCode plugin
+
+## Explore
+
+### Tasks
+- [x] Read and understand existing domain filtering implementation
+- [x] Identify all hardcoded domain values
+- [x] Map all known domain values across workflow YAMLs
+- [x] Understand existing env var (`WORKFLOW_DOMAINS`) and legacy alias (`VIBE_WORKFLOW_DOMAINS`)
+- [x] Identify affected files and usage sites
+- [x] Design solution with environment variables and constructor parameters
+- [x] Design `load_workflows` tool with domain metadata descriptions
+
+### Completed
+- [x] Created development plan file
+- [x] Explored `packages/core/src/workflow-manager.ts` — found two hardcoded domain values
+- [x] Explored `packages/opencode-plugin/src/tool-handlers/start-development.ts` — uses `getAvailableWorkflowsForProject()` which respects domain filtering
+- [x] Explored `packages/cli/src/cli.ts` — uses `getAllAvailableWorkflows()` for workflow copy
+- [x] Explored `packages/mcp-server/src/server-config.ts` — server initialization, tool registration
+- [x] Explored `packages/opencode-plugin/src/server-context.ts` — context builder, creates WorkflowManager
+- [x] Read `.vibe/domain-filtering-research.md` — previous analysis confirms domain filtering is correct in constructor
+- [x] Read `.vibe/opencode-domain-filtering-analysis.md` — confirms existing domain filtering works
+
+## Plan
+
+### Key Decisions
+
+#### A. `parseEnabledDomains()` — Three-level env var chain + constructor override
+
+**Change**: Replace the hardcoded `Set(['code'])` fallback with a four-level environment variable chain that ends with an empty Set (no filtering = all workflows load).
+
+**Precedence chain** (highest to lowest priority):
+1. **Constructor parameter** `defaultDomains?: string | string[]` — programmatic override (highest priority)
+2. **`WORKFLOW_DOMAINS`** env var — canonical runtime configuration
+3. **`DEFAULT_DOMAINS`** env var — new: runtime default when canonical is unset
+4. **`VIBE_WORKFLOW_DOMAINS`** env var — legacy alias (backward compatibility)
+5. **Empty Set** (`new Set()`) — final fallback: no filtering, all workflows load
+
+**Rationale for empty Set fallback**: Previously, if no env var was set, only `code` domain workflows loaded. This was a silent behavior that made other domains unavailable to users who didn't know about `WORKFLOW_DOMAINS`. With an empty Set, the domain filter in `loadPredefinedWorkflows()` (line 553) is bypassed (`this.enabledDomains.size > 0` is false), so all workflows load. This is the expected behavior for users who don't configure domain filtering.
+
+**Implementation** (pseudocode):
+```typescript
+private parseEnabledDomains(): Set<string> {
+  // 1. Constructor parameter (highest priority)
+  if (this._defaultDomains !== null) {
+    const domains = new Set(
+      Array.isArray(this._defaultDomains)
+        ? this._defaultDomains
+        : this._defaultDomains.split(',')
+    );
+    logger.debug('Using constructor default domains', { domains: Array.from(domains) });
+    return domains;
+  }
+
+  // 2. WORKFLOW_DOMAINS (canonical)
+  if (process.env['WORKFLOW_DOMAINS']) {
+    return this._parseDomainString(process.env['WORKFLOW_DOMAINS'], 'WORKFLOW_DOMAINS');
+  }
+
+  // 3. DEFAULT_DOMAINS (new: runtime default)
+  if (process.env['DEFAULT_DOMAINS']) {
+    return this._parseDomainString(process.env['DEFAULT_DOMAINS'], 'DEFAULT_DOMAINS');
+  }
+
+  // 4. VIBE_WORKFLOW_DOMAINS (legacy alias)
+  if (process.env['VIBE_WORKFLOW_DOMAINS']) {
+    return this._parseDomainString(process.env['VIBE_WORKFLOW_DOMAINS'], 'VIBE_WORKFLOW_DOMAINS (legacy)');
+  }
+
+  // 5. Empty Set — no filtering, all workflows load
+  logger.debug('No domain configuration found, loading all workflows');
+  return new Set();
+}
+
+private _parseDomainString(domainString: string, source: string): Set<string> {
+  const domains = new Set(
+    domainString.split(',').map(d => d.trim()).filter(d => d)
+  );
+  logger.debug('Parsed enabled domains', { source, domains: Array.from(domains) });
+  return domains;
+}
+```
+
+#### B. Constructor parameter `defaultDomains`
+
+**Change**: Add an optional `defaultDomains` parameter to the `WorkflowManager` constructor.
+
+**Implementation**:
+```typescript
+export interface WorkflowManagerOptions {
+  defaultDomains?: string | string[];
+}
+
+export class WorkflowManager {
+  private _defaultDomains: string | string[] | null = null;
+
+  constructor(options?: WorkflowManagerOptions) {
+    this.stateMachineLoader = new StateMachineLoader();
+    if (options?.defaultDomains !== undefined) {
+      this._defaultDomains = options.defaultDomains;
+    }
+    this.enabledDomains = this.parseEnabledDomains();
+    this.loadPredefinedWorkflows();
+  }
+}
+```
+
+**Rationale**: Enables testing (no env var manipulation needed), allows library consumers to set defaults programmatically, and provides the highest-priority override in the precedence chain.
+
+#### C. `getAllAvailableWorkflows()` — Use `DEFAULT_ALL_DOMAINS` env var
+
+**Change**: Replace the hardcoded `'code,architecture,office,sdd'` with a configurable `DEFAULT_ALL_DOMAINS` env var.
+
+**Precedence**:
+1. **`DEFAULT_ALL_DOMAINS`** env var — new: explicit list of all available domains
+2. **Hardcoded fallback** `'code,architecture,office,sdd,sdd-crowd,skilled,children'` — all known domains
+
+**Implementation**:
+```typescript
+public getAllAvailableWorkflows(): WorkflowInfo[] {
+  const originalEnv = process.env['WORKFLOW_DOMAINS'];
+  const allDomains = process.env['DEFAULT_ALL_DOMAINS']
+    || 'code,architecture,office,sdd,sdd-crowd,skilled,children';
+
+  process.env['WORKFLOW_DOMAINS'] = allDomains;
+
+  try {
+    const tempManager = new WorkflowManager();
+    return tempManager.getAvailableWorkflows();
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env['WORKFLOW_DOMAINS'] = originalEnv;
+    } else {
+      delete process.env['WORKFLOW_DOMAINS'];
+    }
+  }
+}
+```
+
+**Rationale**: The previous hardcoded list was incomplete (missing `sdd-crowd`, `skilled`, `children`). Using an env var allows runtime customization. The fallback includes all known domains discovered from the 25 workflow YAML files.
+
+#### D. `load_workflows(domains)` tool — Runtime domain switching
+
+**Change**: Add a new tool `load_workflows(domains)` that replaces the current domain set and reloads workflows.
+
+**Domain metadata descriptions** (hard-coded, exposed in tool parameter description):
+```typescript
+const DOMAIN_DESCRIPTIONS: Record<string, string> = {
+  code: 'Standard coding workflows: epcc, tdd, bugfix, minor, greenfield, waterfall, pr-review',
+  architecture: 'Architecture analysis: adr, big-bang-conversion, boundary-testing, business-analysis, c4-analysis',
+  sdd: 'System Design Description workflows: sdd-bugfix, sdd-feature, sdd-greenfield',
+  'sdd-crowd': 'SDD crowd-sourced workflows for distributed teams',
+  skilled: 'Skilled workflows: skilled-bugfix, skilled-epcc, skilled-greenfield',
+  office: 'Office workflows: posts, slides',
+  children: 'Children workflows: game-beginner',
+};
+```
+
+**Tool signature**:
+```typescript
+{
+  name: 'load_workflows',
+  description: 'Load workflows from one or more domains. Replaces the current domain set. Use this to discover workflows from different domains.',
+  inputSchema: {
+    domains: z.string().describe(
+      'Comma-separated domain names to load. Available domains:\n' +
+      '  - code: Standard coding workflows (epcc, tdd, bugfix, minor, greenfield, waterfall, pr-review)\n' +
+      '  - architecture: Architecture analysis (adr, big-bang-conversion, boundary-testing, business-analysis, c4-analysis)\n' +
+      '  - sdd: System Design Description workflows (sdd-bugfix, sdd-feature, sdd-greenfield)\n' +
+      '  - sdd-crowd: SDD crowd-sourced workflows for distributed teams\n' +
+      '  - skilled: Skilled workflows (skilled-bugfix, skilled-epcc, skilled-greenfield)\n' +
+      '  - office: Office workflows (posts, slides)\n' +
+      '  - children: Children workflows (game-beginner)\n\n' +
+      'Examples: "code", "code,architecture", "architecture,office"'
+    ),
+  },
+}
+```
+
+**Core implementation** (`setDomains` method on `WorkflowManager`):
+```typescript
+public setDomains(domains: string | string[]): void {
+  const newSet = new Set(
+    Array.isArray(domains) ? domains : domains.split(',').map(d => d.trim()).filter(d => d)
+  );
+
+  // Validate domains against known set
+  const knownDomains = new Set(Object.keys(DOMAIN_DESCRIPTIONS));
+  for (const domain of newSet) {
+    if (!knownDomains.has(domain)) {
+      throw new Error(`Unknown domain: '${domain}'. Known domains: ${Array.from(knownDomains).join(', ')}`);
+    }
+  }
+
+  // Guard: check for active workflow conflict
+  const activeWorkflow = this.getActiveWorkflow();
+  if (activeWorkflow && activeWorkflow.metadata?.domain && !newSet.has(activeWorkflow.metadata.domain)) {
+    throw new Error(
+      `Cannot switch domains: active workflow '${activeWorkflow.name}' is in domain '${activeWorkflow.metadata.domain}', which is not in the new set. Finish or reset the current workflow first.`
+    );
+  }
+
+  // Update and reload
+  this.enabledDomains = newSet;
+  this.loadPredefinedWorkflows();
+  if (this.lastProjectPath) {
+    this.loadProjectWorkflows(this.lastProjectPath);
+  }
+
+  logger.info('Domains updated', {
+    domains: Array.from(newSet),
+    totalWorkflows: this.predefinedWorkflows.size,
+  });
+}
+```
+
+**Active workflow detection**:
+```typescript
+private getActiveWorkflow(): WorkflowInfo | null {
+  // Check for an active workflow by looking at the conversation state
+  // This could use ConversationManager or a simpler heuristic
+  // For now, use a placeholder — actual implementation depends on ConversationManager API
+  return null; // Placeholder
+}
+```
+
+**Rationale**: The LLM doesn't know about `WORKFLOW_DOMAINS` env vars. This tool gives it a discoverable, self-documenting way to load workflows from any domain. The hard-coded domain descriptions in the tool's parameter description let the LLM understand what each domain offers.
+
+### Test Strategy
+
+#### New Tests — Env var chain (`packages/core/test/unit/workflow-domains-precedence.test.ts`)
+
+1. **`DEFAULT_DOMAINS` env var is used when `WORKFLOW_DOMAINS` is unset**
+   - Set `DEFAULT_DOMAINS=architecture`, verify architecture workflows load
+   - Verify `code` workflows are excluded
+
+2. **`WORKFLOW_DOMAINS` takes precedence over `DEFAULT_DOMAINS`**
+   - Set both: `WORKFLOW_DOMAINS=code`, `DEFAULT_DOMAINS=architecture`
+   - Verify only `code` workflows load
+
+3. **Constructor `defaultDomains` overrides all env vars**
+   - Set `WORKFLOW_DOMAINS=code`, `DEFAULT_DOMAINS=architecture`
+   - Construct with `defaultDomains: 'office'`
+   - Verify only `office` workflows load
+
+4. **Empty Set fallback loads all workflows**
+   - Clear all domain env vars
+   - Construct `WorkflowManager()` with no options
+   - Verify workflows from all 7 domains are loaded
+
+5. **`DEFAULT_ALL_DOMAINS` env var affects `getAllAvailableWorkflows()`**
+   - Set `DEFAULT_ALL_DOMAINS=code,architecture`
+   - Call `getAllAvailableWorkflows()`
+   - Verify only code and architecture workflows returned
+
+6. **`getAllAvailableWorkflows()` includes all known domains by default**
+   - Clear all env vars
+   - Call `getAllAvailableWorkflows()`
+   - Verify workflows from all 7 domains are present
+
+#### New Tests — Domain switching (`packages/core/test/unit/workflow-domain-switching.test.ts`)
+
+7. **`setDomains()` replaces current domains and reloads workflows**
+   - Start with `code` domain
+   - Call `setDomains('architecture')`
+   - Verify only architecture workflows are available
+
+8. **`setDomains()` accepts comma-separated domains**
+   - Call `setDomains('code,architecture')`
+   - Verify both code and architecture workflows are available
+
+9. **`setDomains()` rejects unknown domains**
+   - Call `setDomains('nonexistent')`
+   - Verify Error is thrown
+
+10. **`setDomains()` blocks switching away from active workflow's domain**
+    - Start with `code` domain, simulate active `epcc` workflow
+    - Call `setDomains('architecture')`
+    - Verify Error is thrown with helpful message
+
+11. **`setDomains()` allows switching within same domain**
+    - Start with `code` domain, active `epcc` workflow
+    - Call `setDomains('code,architecture')`
+    - Verify successful (epcc domain is still in the set)
+
+12. **`setDomains()` reloads project workflows after domain change**
+    - Load project workflows, then call `setDomains`
+    - Verify project workflows are reloaded
+
+#### Updated Existing Tests
+
+- **Existing test 1** (`WORKFLOW_DOMAINS` preference): Already correct — sets `WORKFLOW_DOMAINS` explicitly, no change needed.
+- **Existing test 2** (`VIBE_WORKFLOW_DOMAINS` fallback): Already correct — clears `WORKFLOW_DOMAINS`, sets `VIBE_WORKFLOW_DOMAINS`, verifies fallback behavior.
+
+### Affected Files (Detailed)
+
+1. **`packages/core/src/workflow-manager.ts`** (primary changes):
+   - Add `WorkflowManagerOptions` interface
+   - Add `_defaultDomains` private field
+   - Modify constructor to accept `options` parameter
+   - Refactor `parseEnabledDomains()` to implement four-level env var chain
+   - Extract `_parseDomainString()` helper method
+   - Add `setDomains(domains: string | string[]): void` method
+   - Add `getActiveWorkflow(): WorkflowInfo | null` helper (or use existing ConversationManager)
+   - Add `DOMAIN_DESCRIPTIONS` constant
+   - Update `getAllAvailableWorkflows()` to use `DEFAULT_ALL_DOMAINS`
+
+2. **`packages/mcp-server/src/server-config.ts`**:
+   - Register `load_workflows` tool with domain descriptions in parameter schema
+
+3. **`packages/opencode-plugin/src/tool-handlers/load-workflows.ts`** (new file):
+   - Create tool handler that delegates to `WorkflowManager.setDomains()`
+   - Reuse same domain descriptions as MCP server
+
+4. **`packages/core/test/unit/workflow-domains-precedence.test.ts`** (new tests):
+   - Add 6 new test cases for env var chain and `DEFAULT_ALL_DOMAINS`
+
+5. **`packages/core/test/unit/workflow-domain-switching.test.ts`** (new file):
+   - Add 6 new test cases for `setDomains()` method
+
+### Edge Cases & Considerations
+
+1. **Thread safety**: `process.env` is global and shared. Tests must restore env vars in `afterEach`. The `getAllAvailableWorkflows()` method already does this with try/finally.
+
+2. **Constructor signature change**: Adding `options?: WorkflowManagerOptions` is backward compatible — existing code calling `new WorkflowManager()` continues to work.
+
+3. **Empty Set semantics**: When `enabledDomains` is empty, `loadPredefinedWorkflows()` line 553 checks `this.enabledDomains.size > 0` before filtering, so all workflows load. This is the correct behavior for "no configuration."
+
+4. **Domain list completeness**: The fallback for `DEFAULT_ALL_DOMAINS` includes all 7 known domains: `code,architecture,office,sdd,sdd-crowd,skilled,children`. If new domains are added to workflow YAMLs in the future, the fallback should be updated.
+
+5. **Active workflow detection**: The `getActiveWorkflow()` method needs to determine if a workflow is currently running. This may require access to `ConversationManager` or checking the conversation state. If the API isn't available, we can use a simpler heuristic (e.g., check if any conversation exists for the project).
+
+6. **Logging**: All four env var sources log which source was used, making debugging easy. `setDomains()` logs the new domain set and total workflow count.
+
+7. **Tool registration duplication**: The `load_workflows` tool will be registered in both MCP server and OpenCode plugin. The domain descriptions should be shared — either via a shared constant in `@codemcp/workflows-core` or via a utility function.
+
+### Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Breaking existing users who rely on `code` default | Low | Empty Set loads ALL workflows, which is a superset of `code` |
+| Tests affected by global `process.env` | Medium | `afterEach` cleanup + explicit env var setting in each test |
+| CLI `workflow copy` command affected | Low | `getAllAvailableWorkflows()` now includes more domains, which is strictly better |
+| Backward compat with `VIBE_WORKFLOW_DOMAINS` | Low | Explicitly tested, same precedence as before (below `WORKFLOW_DOMAINS`) |
+| Active workflow detection API unavailable | Medium | Use fallback heuristic or skip the guard if not available |
+| Tool registration duplication | Low | Share domain descriptions via shared constant in core package |
+
+## Code
+
+### Tasks
+- [x] Add `DEFAULT_DOMAINS` env var support in `parseEnabledDomains()`
+- [x] Add `defaultDomains` constructor parameter for programmatic override
+- [x] Update `getAllAvailableWorkflows()` to use `DEFAULT_ALL_DOMAINS` env var
+- [x] Add `setDomains()` method to `WorkflowManager`
+- [x] Add `getActiveWorkflow()` helper (or use ConversationManager)
+- [x] Add `DOMAIN_DESCRIPTIONS` constant to core package
+- [x] Register `load_workflows` tool in MCP server
+- [x] Register `load_workflows` tool in OpenCode plugin
+- [x] Add unit tests for env var chain (9 tests)
+- [x] Add unit tests for `setDomains()` (9 tests)
+- [x] Update existing tests to account for new precedence chain
+- [x] Verify backward compatibility with `VIBE_WORKFLOW_DOMAINS`
+
+### Completed
+- [x] Refactored `parseEnabledDomains()` to implement four-level env var chain: constructor param > `WORKFLOW_DOMAINS` > `DEFAULT_DOMAINS` > `VIBE_WORKFLOW_DOMAINS` > empty Set
+- [x] Added `WorkflowManagerOptions` interface with `defaultDomains` parameter
+- [x] Updated `getAllAvailableWorkflows()` to use `DEFAULT_ALL_DOMAINS` env var with full 7-domain fallback
+- [x] Added `setDomains(domains)` method with domain validation and empty-set reload
+- [x] Added `getActiveWorkflow()` helper (returns null — active workflow detection handled by ConversationManager)
+- [x] Added `DOMAIN_DESCRIPTIONS` constant exported from `@codemcp/workflows-core`
+- [x] Registered `load_workflows` tool in MCP server (`server-config.ts` + `tool-handlers/load-workflows.ts`)
+- [x] Registered `load_workflows` tool in OpenCode plugin (`plugin.ts` + `tool-handlers/load-workflows.ts`)
+- [x] Fixed pre-existing bug: `loadPredefinedWorkflows()` now clears `predefinedWorkflows` and `workflowInfos` maps before reloading
+- [x] Updated `workflow-domain-filtering.test.ts` to expect all-workflows default (empty Set)
+- [x] All 18 new tests pass (9 env var chain + 9 domain switching)
+- [x] Backward compatibility verified: `VIBE_WORKFLOW_DOMAINS` still works as lowest-priority env var
+
+### Key Decisions
+- **Empty Set fallback**: When no domain config is set, ALL workflows load (no filtering). This is the expected behavior for users who don't configure domain filtering.
+- **`getActiveWorkflow()` returns null**: The actual active workflow detection is handled by `ConversationManager`. The guard in `setDomains()` is a placeholder for future integration.
+- **`loadPredefinedWorkflows()` now clears maps**: This was a pre-existing bug that became visible when `setDomains()` called `loadPredefinedWorkflows()`. Old workflows would accumulate across domain switches.
+- **Domain descriptions in tool parameters**: Both MCP server and OpenCode plugin embed the full domain descriptions in the tool's parameter schema, allowing the LLM to discover and choose domains intelligently.
+
+## Commit
+
+### Tasks
+- [ ] Commit with conventional commit message
+- [ ] Push branch
+
+### Completed
+*None yet*
+
+
+---
+*This plan is maintained by the LLM. Tool responses provide guidance on which section to focus on and what tasks to work on.*

--- a/.vibe/development-plan-refactor-configurable-default-domain.md
+++ b/.vibe/development-plan-refactor-configurable-default-domain.md
@@ -478,6 +478,7 @@ private getActiveWorkflow(): WorkflowInfo | null {
 ### Completed
 - [x] Initial commit `1999cd7`: feat — configurable default domain
 - [x] Follow-up commit `80dcf69`: refactor — move domain descriptions from tool parameter to resource
+- [x] Follow-up commit `726c749`: refactor — rename domain-info:// resource to domain://
 - [x] PR: https://github.com/codemcp/workflows/pull/281
 
 ### Domain Descriptions (improved)

--- a/packages/core/src/workflow-manager.ts
+++ b/packages/core/src/workflow-manager.ts
@@ -38,6 +38,20 @@ export const DOMAIN_DESCRIPTIONS: Record<string, string> = {
     'Educational game development for children ages 8-12: simplified, age-appropriate programming concepts with frequent positive reinforcement and incremental achievement',
 };
 
+/**
+ * Known domain names — use this constant to avoid duplicating the domain list.
+ * Import from '@codemcp/workflows-core' in plugin/tool handler code.
+ */
+export const KNOWN_DOMAIN_NAMES = Object.keys(DOMAIN_DESCRIPTIONS) as [
+  'code',
+  'architecture',
+  'sdd',
+  'sdd-crowd',
+  'skilled',
+  'office',
+  'children',
+];
+
 export interface WorkflowManagerOptions {
   /**
    * Default domains to use for workflow filtering.
@@ -133,9 +147,9 @@ export class WorkflowManager {
       );
     }
 
-    // 5. Empty Set — no filtering, all workflows load
-    logger.debug('No domain configuration found, loading all workflows');
-    return new Set();
+    // 5. Default — 'code' (maintains backward-compatible out-of-the-box behavior)
+    logger.debug('No domain configuration found, using default: code');
+    return new Set(['code']);
   }
 
   /**
@@ -264,47 +278,27 @@ export class WorkflowManager {
    * Uses DEFAULT_ALL_DOMAINS env var if set, otherwise falls back to all known domains.
    */
   public getAllAvailableWorkflows(): WorkflowInfo[] {
-    // Create a temporary manager with all domains enabled
-    const originalEnv = process.env['WORKFLOW_DOMAINS'];
+    // Use constructor param instead of env var mutation for thread safety
     const allDomains =
       process.env['DEFAULT_ALL_DOMAINS'] ||
       'code,architecture,office,sdd,sdd-crowd,skilled,children';
-
-    process.env['WORKFLOW_DOMAINS'] = allDomains;
-
-    try {
-      const tempManager = new WorkflowManager();
-      return tempManager.getAvailableWorkflows();
-    } finally {
-      if (originalEnv !== undefined) {
-        process.env['WORKFLOW_DOMAINS'] = originalEnv;
-      } else {
-        delete process.env['WORKFLOW_DOMAINS'];
-      }
-    }
-  }
-
-  /**
-   * Get information about any currently active workflow.
-   * Returns null if no active workflow is detected.
-   */
-  private getActiveWorkflow(): WorkflowInfo | null {
-    // Check if any loaded workflow has metadata indicating it's active.
-    // Since WorkflowManager doesn't track conversation state directly,
-    // we return null here. The actual active workflow detection is handled
-    // by ConversationManager. This method exists as a placeholder for
-    // future integration if needed.
-    return null;
+    const tempManager = new WorkflowManager({ defaultDomains: allDomains });
+    return tempManager.getAvailableWorkflows();
   }
 
   /**
    * Replace the current domain set and reload workflows.
    *
    * This allows runtime switching of domains without recreating the WorkflowManager.
-   * Validates domains against known set and checks for active workflow conflicts.
+   * Validates domains against known set.
    *
-   * @param domains - Comma-separated string or array of domain names
-   * @throws Error if an unknown domain is provided or if switching would conflict with an active workflow
+   * NOTE: Active workflow conflict detection is not yet implemented (see getActiveWorkflow).
+   * Callers can switch domains freely regardless of active workflow state.
+   *
+   * @param domains - Comma-separated string or array of domain names.
+   *   Pass an empty string or empty array to load ALL workflows (no domain filtering).
+   *   To reset to the default domain, pass 'code' explicitly.
+   * @throws Error if an unknown domain is provided
    */
   public setDomains(domains: string | string[]): void {
     const newSet = new Set(
@@ -326,17 +320,9 @@ export class WorkflowManager {
       }
     }
 
-    // Guard: check for active workflow conflict
-    const activeWorkflow = this.getActiveWorkflow();
-    if (
-      activeWorkflow &&
-      activeWorkflow.metadata?.domain &&
-      !newSet.has(activeWorkflow.metadata.domain)
-    ) {
-      throw new Error(
-        `Cannot switch domains: active workflow '${activeWorkflow.name}' is in domain '${activeWorkflow.metadata.domain}', which is not in the new set. Finish or reset the current workflow first.`
-      );
-    }
+    // NOTE: Active workflow conflict detection is not yet implemented.
+    // getActiveWorkflow() always returns null until ConversationManager integration is complete.
+    // Callers can switch domains freely regardless of active workflow state.
 
     // Update and reload
     this.enabledDomains = newSet;

--- a/packages/core/src/workflow-manager.ts
+++ b/packages/core/src/workflow-manager.ts
@@ -15,6 +15,38 @@ import { ConfigManager } from './config-manager.js';
 
 const logger = createLogger('WorkflowManager');
 
+/**
+ * Domain descriptions for tool parameter metadata.
+ * These are exposed to the LLM via the load_workflows tool to help it
+ * discover and choose domains intelligently.
+ *
+ * Each description summarizes what the domain is suitable for,
+ * based on the actual workflow YAML descriptions.
+ */
+export const DOMAIN_DESCRIPTIONS: Record<string, string> = {
+  code: 'Day-to-day software engineering: features (epcc), test-driven development (tdd), bug fixes (bugfix, minor), greenfield projects (greenfield), large structured development (waterfall), and code reviews (pr-review)',
+  architecture:
+    'System understanding and planning: architectural decisions (adr), legacy system modernization (big-bang-conversion), API and boundary analysis (boundary-testing), business capability modeling (business-analysis), and progressive architecture discovery (c4-analysis)',
+  sdd: 'Specification-driven development: write detailed specs before coding — structured requirements, user stories, testability focus, and constitutional compliance gates for bugfixes, features, and greenfield projects',
+  'sdd-crowd':
+    'Multi-agent collaborative specification-driven development: role-based handoffs between business analysts (specify), architects (plan), and developers (implement) for coordinated distributed teams',
+  skilled:
+    'Skill-augmented development: explicit prompts to apply specialized expertise (architecture, coding, testing, application design) at each phase — for scenarios where best practices and domain expertise should be leveraged',
+  office:
+    'Content creation and communication: structured workflows for writing blog posts (discovery through distribution) and creating slide presentations (ideate through deliver)',
+  children:
+    'Educational game development for children ages 8-12: simplified, age-appropriate programming concepts with frequent positive reinforcement and incremental achievement',
+};
+
+export interface WorkflowManagerOptions {
+  /**
+   * Default domains to use for workflow filtering.
+   * Takes precedence over all environment variables.
+   * Can be a comma-separated string or an array of domain names.
+   */
+  defaultDomains?: string | string[];
+}
+
 export interface WorkflowInfo {
   name: string;
   displayName: string;
@@ -41,43 +73,88 @@ export class WorkflowManager {
   private stateMachineLoader: StateMachineLoader;
   private lastProjectPath: string | null = null; // Track last loaded project path
   private enabledDomains: Set<string>;
+  private _defaultDomains: string | string[] | null = null; // Constructor override
 
-  constructor() {
+  constructor(options?: WorkflowManagerOptions) {
     this.stateMachineLoader = new StateMachineLoader();
+    if (options?.defaultDomains !== undefined) {
+      this._defaultDomains = options.defaultDomains;
+    }
     this.enabledDomains = this.parseEnabledDomains();
     this.loadPredefinedWorkflows();
   }
 
   /**
-   * Parse enabled domains from environment variable.
-   * WORKFLOW_DOMAINS is the canonical name.
-   * VIBE_WORKFLOW_DOMAINS is supported as a legacy alias for backward compatibility.
-   * WORKFLOW_DOMAINS takes precedence when both are set.
+   * Parse enabled domains from environment variable with four-level precedence chain:
+   * 1. Constructor parameter `defaultDomains` (highest priority)
+   * 2. `WORKFLOW_DOMAINS` env var (canonical runtime configuration)
+   * 3. `DEFAULT_DOMAINS` env var (new: runtime default when canonical is unset)
+   * 4. `VIBE_WORKFLOW_DOMAINS` env var (legacy alias for backward compatibility)
+   * 5. Empty Set — final fallback: no filtering, all workflows load
    */
   private parseEnabledDomains(): Set<string> {
-    // WORKFLOW_DOMAINS (canonical) takes precedence over VIBE_WORKFLOW_DOMAINS (legacy alias)
-    const domainsEnv =
-      process.env['WORKFLOW_DOMAINS'] || process.env['VIBE_WORKFLOW_DOMAINS'];
-
-    if (!domainsEnv) {
-      logger.debug('No domain configuration found, using default: code');
-      return new Set(['code']);
+    // 1. Constructor parameter (highest priority)
+    if (this._defaultDomains !== null) {
+      const domains = new Set(
+        Array.isArray(this._defaultDomains)
+          ? this._defaultDomains
+          : this._defaultDomains
+              .split(',')
+              .map(d => d.trim())
+              .filter(d => d)
+      );
+      logger.debug('Using constructor default domains', {
+        domains: Array.from(domains),
+      });
+      return domains;
     }
 
+    // 2. WORKFLOW_DOMAINS (canonical)
+    if (process.env['WORKFLOW_DOMAINS']) {
+      return this._parseDomainString(
+        process.env['WORKFLOW_DOMAINS'],
+        'WORKFLOW_DOMAINS'
+      );
+    }
+
+    // 3. DEFAULT_DOMAINS (new: runtime default)
+    if (process.env['DEFAULT_DOMAINS']) {
+      return this._parseDomainString(
+        process.env['DEFAULT_DOMAINS'],
+        'DEFAULT_DOMAINS'
+      );
+    }
+
+    // 4. VIBE_WORKFLOW_DOMAINS (legacy alias)
+    if (process.env['VIBE_WORKFLOW_DOMAINS']) {
+      return this._parseDomainString(
+        process.env['VIBE_WORKFLOW_DOMAINS'],
+        'VIBE_WORKFLOW_DOMAINS (legacy)'
+      );
+    }
+
+    // 5. Empty Set — no filtering, all workflows load
+    logger.debug('No domain configuration found, loading all workflows');
+    return new Set();
+  }
+
+  /**
+   * Parse a comma-separated domain string into a Set.
+   */
+  private _parseDomainString(
+    domainString: string,
+    source: string
+  ): Set<string> {
     const domains = new Set(
-      domainsEnv
+      domainString
         .split(',')
         .map(d => d.trim())
         .filter(d => d)
     );
-
     logger.debug('Parsed enabled domains', {
-      source: process.env['WORKFLOW_DOMAINS']
-        ? 'WORKFLOW_DOMAINS'
-        : 'VIBE_WORKFLOW_DOMAINS (legacy)',
+      source,
       domains: Array.from(domains),
     });
-
     return domains;
   }
 
@@ -183,12 +260,17 @@ export class WorkflowManager {
     }
   }
   /**
-   * Get all available workflows regardless of domain filtering
+   * Get all available workflows regardless of domain filtering.
+   * Uses DEFAULT_ALL_DOMAINS env var if set, otherwise falls back to all known domains.
    */
   public getAllAvailableWorkflows(): WorkflowInfo[] {
     // Create a temporary manager with all domains enabled
     const originalEnv = process.env['WORKFLOW_DOMAINS'];
-    process.env['WORKFLOW_DOMAINS'] = 'code,architecture,office,sdd';
+    const allDomains =
+      process.env['DEFAULT_ALL_DOMAINS'] ||
+      'code,architecture,office,sdd,sdd-crowd,skilled,children';
+
+    process.env['WORKFLOW_DOMAINS'] = allDomains;
 
     try {
       const tempManager = new WorkflowManager();
@@ -200,6 +282,73 @@ export class WorkflowManager {
         delete process.env['WORKFLOW_DOMAINS'];
       }
     }
+  }
+
+  /**
+   * Get information about any currently active workflow.
+   * Returns null if no active workflow is detected.
+   */
+  private getActiveWorkflow(): WorkflowInfo | null {
+    // Check if any loaded workflow has metadata indicating it's active.
+    // Since WorkflowManager doesn't track conversation state directly,
+    // we return null here. The actual active workflow detection is handled
+    // by ConversationManager. This method exists as a placeholder for
+    // future integration if needed.
+    return null;
+  }
+
+  /**
+   * Replace the current domain set and reload workflows.
+   *
+   * This allows runtime switching of domains without recreating the WorkflowManager.
+   * Validates domains against known set and checks for active workflow conflicts.
+   *
+   * @param domains - Comma-separated string or array of domain names
+   * @throws Error if an unknown domain is provided or if switching would conflict with an active workflow
+   */
+  public setDomains(domains: string | string[]): void {
+    const newSet = new Set(
+      Array.isArray(domains)
+        ? domains
+        : domains
+            .split(',')
+            .map(d => d.trim())
+            .filter(d => d)
+    );
+
+    // Validate domains against known set
+    const knownDomains = new Set(Object.keys(DOMAIN_DESCRIPTIONS));
+    for (const domain of newSet) {
+      if (!knownDomains.has(domain)) {
+        throw new Error(
+          `Unknown domain: '${domain}'. Known domains: ${Array.from(knownDomains).join(', ')}`
+        );
+      }
+    }
+
+    // Guard: check for active workflow conflict
+    const activeWorkflow = this.getActiveWorkflow();
+    if (
+      activeWorkflow &&
+      activeWorkflow.metadata?.domain &&
+      !newSet.has(activeWorkflow.metadata.domain)
+    ) {
+      throw new Error(
+        `Cannot switch domains: active workflow '${activeWorkflow.name}' is in domain '${activeWorkflow.metadata.domain}', which is not in the new set. Finish or reset the current workflow first.`
+      );
+    }
+
+    // Update and reload
+    this.enabledDomains = newSet;
+    this.loadPredefinedWorkflows();
+    if (this.lastProjectPath) {
+      this.loadProjectWorkflows(this.lastProjectPath);
+    }
+
+    logger.info('Domains updated', {
+      domains: Array.from(newSet),
+      totalWorkflows: this.predefinedWorkflows.size,
+    });
   }
 
   public getAvailableWorkflows(): WorkflowInfo[] {
@@ -525,6 +674,10 @@ export class WorkflowManager {
    */
   private loadPredefinedWorkflows(): void {
     try {
+      // Clear existing workflows before reloading (important for setDomains)
+      this.predefinedWorkflows.clear();
+      this.workflowInfos.clear();
+
       const workflowsDir = this.findWorkflowsDirectory();
 
       if (!workflowsDir || !fs.existsSync(workflowsDir)) {

--- a/packages/core/test/unit/workflow-domain-filtering.test.ts
+++ b/packages/core/test/unit/workflow-domain-filtering.test.ts
@@ -16,18 +16,22 @@ describe('Workflow Domain Filtering', () => {
     }
   });
 
-  it('should load all workflows when no domain filter is set (empty Set fallback)', () => {
+  it('should load only code workflows when no domain filter is set (default: code)', () => {
     delete process.env.WORKFLOW_DOMAINS;
 
     const manager = new WorkflowManager();
     const workflows = manager.getAvailableWorkflows();
 
-    // With empty Set, all workflows load (no filtering applied)
-    // Should have workflows from multiple domains
-    const domains = new Set(
-      workflows.map(w => w.metadata?.domain).filter(Boolean) as string[]
+    // Default is 'code' — should only include code domain workflows
+    const codeWorkflows = workflows.filter(
+      w => !w.metadata?.domain || w.metadata.domain === 'code'
     );
-    expect(domains.size).toBeGreaterThan(1);
+    const nonCodeWorkflows = workflows.filter(
+      w => w.metadata?.domain && w.metadata.domain !== 'code'
+    );
+
+    expect(codeWorkflows.length).toBeGreaterThan(0);
+    expect(nonCodeWorkflows.length).toBe(0);
   });
 
   it('should filter workflows by domain when WORKFLOW_DOMAINS is set', () => {

--- a/packages/core/test/unit/workflow-domain-filtering.test.ts
+++ b/packages/core/test/unit/workflow-domain-filtering.test.ts
@@ -16,22 +16,18 @@ describe('Workflow Domain Filtering', () => {
     }
   });
 
-  it('should load only code workflows when no domain filter is set', () => {
+  it('should load all workflows when no domain filter is set (empty Set fallback)', () => {
     delete process.env.WORKFLOW_DOMAINS;
 
     const manager = new WorkflowManager();
     const workflows = manager.getAvailableWorkflows();
 
-    // Should only include code domain workflows and workflows without domain
-    const codeWorkflows = workflows.filter(
-      w => !w.metadata?.domain || w.metadata.domain === 'code'
+    // With empty Set, all workflows load (no filtering applied)
+    // Should have workflows from multiple domains
+    const domains = new Set(
+      workflows.map(w => w.metadata?.domain).filter(Boolean) as string[]
     );
-    const nonCodeWorkflows = workflows.filter(
-      w => w.metadata?.domain && w.metadata.domain !== 'code'
-    );
-
-    expect(codeWorkflows.length).toBeGreaterThan(0);
-    expect(nonCodeWorkflows.length).toBe(0);
+    expect(domains.size).toBeGreaterThan(1);
   });
 
   it('should filter workflows by domain when WORKFLOW_DOMAINS is set', () => {

--- a/packages/core/test/unit/workflow-domain-switching.test.ts
+++ b/packages/core/test/unit/workflow-domain-switching.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { WorkflowManager } from '../../src/workflow-manager.js';
+
+describe('setDomains() — runtime domain switching', () => {
+  let manager: WorkflowManager;
+  const originalVibe = process.env.VIBE_WORKFLOW_DOMAINS;
+  const originalWorkflow = process.env.WORKFLOW_DOMAINS;
+  const originalDefault = process.env.DEFAULT_DOMAINS;
+  const originalDefaultAll = process.env.DEFAULT_ALL_DOMAINS;
+
+  beforeEach(() => {
+    // Clear all domain env vars for clean state
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['DEFAULT_DOMAINS'];
+    delete process.env['DEFAULT_ALL_DOMAINS'];
+
+    // Start with code domain
+    process.env['WORKFLOW_DOMAINS'] = 'code';
+    manager = new WorkflowManager();
+  });
+
+  afterEach(() => {
+    if (originalVibe) process.env.VIBE_WORKFLOW_DOMAINS = originalVibe;
+    else delete process.env.VIBE_WORKFLOW_DOMAINS;
+
+    if (originalWorkflow) process.env.WORKFLOW_DOMAINS = originalWorkflow;
+    else delete process.env.WORKFLOW_DOMAINS;
+
+    if (originalDefault) process.env.DEFAULT_DOMAINS = originalDefault;
+    else delete process.env.DEFAULT_DOMAINS;
+
+    if (originalDefaultAll)
+      process.env.DEFAULT_ALL_DOMAINS = originalDefaultAll;
+    else delete process.env.DEFAULT_ALL_DOMAINS;
+  });
+
+  it('should replace current domains and reload workflows', () => {
+    const initialWorkflows = manager.getAvailableWorkflows();
+    const initialNames = initialWorkflows.map(w => w.name);
+
+    // Verify we start with code workflows
+    expect(initialNames.some(w => ['epcc', 'tdd'].includes(w))).toBe(true);
+
+    // Switch to architecture domain
+    manager.setDomains('architecture');
+
+    const updatedWorkflows = manager.getAvailableWorkflows();
+    const updatedNames = updatedWorkflows.map(w => w.name);
+
+    // Should now have architecture workflows
+    expect(
+      updatedNames.some(w => ['adr', 'big-bang-conversion'].includes(w))
+    ).toBe(true);
+
+    // Should no longer have code workflows
+    expect(updatedNames.some(w => ['epcc', 'tdd'].includes(w))).toBe(false);
+  });
+
+  it('should accept comma-separated domains', () => {
+    manager.setDomains('code,architecture');
+
+    const workflows = manager.getAvailableWorkflows();
+    const workflowNames = workflows.map(w => w.name);
+
+    expect(workflowNames.some(w => ['epcc', 'tdd'].includes(w))).toBe(true);
+    expect(
+      workflowNames.some(w => ['adr', 'big-bang-conversion'].includes(w))
+    ).toBe(true);
+  });
+
+  it('should accept array of domains', () => {
+    manager.setDomains(['code', 'architecture', 'office']);
+
+    const workflows = manager.getAvailableWorkflows();
+    const workflowNames = workflows.map(w => w.name);
+
+    expect(workflowNames.some(w => ['epcc', 'tdd'].includes(w))).toBe(true);
+    expect(
+      workflowNames.some(w => ['adr', 'big-bang-conversion'].includes(w))
+    ).toBe(true);
+    expect(workflowNames.some(w => ['posts', 'slides'].includes(w))).toBe(true);
+  });
+
+  it('should reject unknown domains with a helpful error', () => {
+    expect(() => manager.setDomains('nonexistent')).toThrow('Unknown domain');
+    expect(() => manager.setDomains('nonexistent')).toThrow('Known domains');
+  });
+
+  it('should reject multiple unknown domains', () => {
+    expect(() => manager.setDomains('nonexistent,also-invalid')).toThrow(
+      'Unknown domain'
+    );
+  });
+
+  it('should allow switching to a superset of current domain', () => {
+    // Start with code, switch to code+architecture
+    manager.setDomains('code,architecture');
+
+    const workflows = manager.getAvailableWorkflows();
+    expect(workflows.length).toBeGreaterThan(0);
+  });
+
+  it('should handle empty domain string gracefully', () => {
+    // Empty string should result in empty set (all workflows load)
+    manager.setDomains('');
+
+    const workflows = manager.getAvailableWorkflows();
+    // With empty set, all workflows load (no filtering)
+    expect(workflows.length).toBeGreaterThan(0);
+  });
+
+  it('should strip whitespace from domain names', () => {
+    manager.setDomains(' code , architecture ');
+
+    const workflows = manager.getAvailableWorkflows();
+    const workflowNames = workflows.map(w => w.name);
+
+    expect(workflowNames.some(w => ['epcc', 'tdd'].includes(w))).toBe(true);
+    expect(
+      workflowNames.some(w => ['adr', 'big-bang-conversion'].includes(w))
+    ).toBe(true);
+  });
+
+  it('should provide DOMAIN_DESCRIPTIONS constant with all known domains', () => {
+    // Import the DOMAIN_DESCRIPTIONS constant
+    // We test it indirectly through setDomains validation
+    // All known domains should be accepted without error
+    const knownDomains = [
+      'code',
+      'architecture',
+      'sdd',
+      'sdd-crowd',
+      'skilled',
+      'office',
+      'children',
+    ];
+
+    for (const domain of knownDomains) {
+      expect(() => manager.setDomains(domain)).not.toThrow();
+    }
+  });
+});

--- a/packages/core/test/unit/workflow-domains-precedence.test.ts
+++ b/packages/core/test/unit/workflow-domains-precedence.test.ts
@@ -4,6 +4,8 @@ import { WorkflowManager } from '../../src/workflow-manager.js';
 describe('WORKFLOW_DOMAINS precedence (backward compat)', () => {
   const originalVibe = process.env.VIBE_WORKFLOW_DOMAINS;
   const originalWorkflow = process.env.WORKFLOW_DOMAINS;
+  const originalDefault = process.env.DEFAULT_DOMAINS;
+  const originalDefaultAll = process.env.DEFAULT_ALL_DOMAINS;
 
   afterEach(() => {
     if (originalVibe) process.env.VIBE_WORKFLOW_DOMAINS = originalVibe;
@@ -11,6 +13,13 @@ describe('WORKFLOW_DOMAINS precedence (backward compat)', () => {
 
     if (originalWorkflow) process.env.WORKFLOW_DOMAINS = originalWorkflow;
     else delete process.env.WORKFLOW_DOMAINS;
+
+    if (originalDefault) process.env.DEFAULT_DOMAINS = originalDefault;
+    else delete process.env.DEFAULT_DOMAINS;
+
+    if (originalDefaultAll)
+      process.env.DEFAULT_ALL_DOMAINS = originalDefaultAll;
+    else delete process.env.DEFAULT_ALL_DOMAINS;
   });
 
   it('should prefer WORKFLOW_DOMAINS over legacy VIBE_WORKFLOW_DOMAINS when both are set', () => {
@@ -68,5 +77,156 @@ describe('WORKFLOW_DOMAINS precedence (backward compat)', () => {
 
     expect(hasCode).toBe(true);
     expect(hasArchitecture).toBe(false);
+  });
+
+  it('should use DEFAULT_DOMAINS when WORKFLOW_DOMAINS is unset', () => {
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+    delete process.env['DEFAULT_DOMAINS'];
+
+    process.env['DEFAULT_DOMAINS'] = 'architecture';
+
+    const manager = new WorkflowManager();
+    const workflows = manager.getAvailableWorkflows();
+
+    const workflowNames = workflows.map(w => w.name);
+    const hasArchitecture = workflowNames.some(w =>
+      ['adr', 'big-bang-conversion'].includes(w)
+    );
+    const hasCode = workflowNames.some(w =>
+      ['epcc', 'tdd', 'bugfix', 'minor'].includes(w)
+    );
+
+    expect(hasArchitecture).toBe(true);
+    expect(hasCode).toBe(false);
+  });
+
+  it('should prefer WORKFLOW_DOMAINS over DEFAULT_DOMAINS', () => {
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+
+    process.env['WORKFLOW_DOMAINS'] = 'code';
+    process.env['DEFAULT_DOMAINS'] = 'architecture';
+
+    const manager = new WorkflowManager();
+    const workflows = manager.getAvailableWorkflows();
+
+    const workflowNames = workflows.map(w => w.name);
+    const hasCode = workflowNames.some(w =>
+      ['epcc', 'tdd', 'bugfix', 'minor'].includes(w)
+    );
+    const hasArchitecture = workflowNames.some(w =>
+      ['adr', 'big-bang-conversion'].includes(w)
+    );
+
+    expect(hasCode).toBe(true);
+    expect(hasArchitecture).toBe(false);
+  });
+
+  it('should prefer DEFAULT_DOMAINS over VIBE_WORKFLOW_DOMAINS', () => {
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+
+    process.env['DEFAULT_DOMAINS'] = 'architecture';
+    process.env['VIBE_WORKFLOW_DOMAINS'] = 'code';
+
+    const manager = new WorkflowManager();
+    const workflows = manager.getAvailableWorkflows();
+
+    const workflowNames = workflows.map(w => w.name);
+    const hasArchitecture = workflowNames.some(w =>
+      ['adr', 'big-bang-conversion'].includes(w)
+    );
+    const hasCode = workflowNames.some(w =>
+      ['epcc', 'tdd', 'bugfix', 'minor'].includes(w)
+    );
+
+    expect(hasArchitecture).toBe(true);
+    expect(hasCode).toBe(false);
+  });
+
+  it('should use constructor defaultDomains when provided (overrides all env vars)', () => {
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+    delete process.env['DEFAULT_DOMAINS'];
+
+    process.env['WORKFLOW_DOMAINS'] = 'code';
+    process.env['DEFAULT_DOMAINS'] = 'architecture';
+
+    const manager = new WorkflowManager({ defaultDomains: 'office' });
+    const workflows = manager.getAvailableWorkflows();
+
+    const workflowNames = workflows.map(w => w.name);
+    const hasOffice = workflowNames.some(w => ['posts', 'slides'].includes(w));
+    const hasCode = workflowNames.some(w =>
+      ['epcc', 'tdd', 'bugfix', 'minor'].includes(w)
+    );
+    const hasArchitecture = workflowNames.some(w =>
+      ['adr', 'big-bang-conversion'].includes(w)
+    );
+
+    expect(hasOffice).toBe(true);
+    expect(hasCode).toBe(false);
+    expect(hasArchitecture).toBe(false);
+  });
+
+  it('should load all workflows when no domain configuration is set (empty Set fallback)', () => {
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+    delete process.env['DEFAULT_DOMAINS'];
+
+    const manager = new WorkflowManager();
+    const workflows = manager.getAvailableWorkflows();
+
+    // Collect all unique domains from loaded workflows
+    const domains = new Set(
+      workflows.map(w => w.metadata?.domain).filter(Boolean) as string[]
+    );
+
+    // Should have workflows from multiple domains, not just 'code'
+    expect(domains.size).toBeGreaterThan(1);
+  });
+
+  it('should use DEFAULT_ALL_DOMAINS env var in getAllAvailableWorkflows()', () => {
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+    delete process.env['DEFAULT_DOMAINS'];
+    delete process.env['DEFAULT_ALL_DOMAINS'];
+
+    process.env['DEFAULT_ALL_DOMAINS'] = 'code,office';
+
+    const manager = new WorkflowManager();
+    const allWorkflows = manager.getAllAvailableWorkflows();
+
+    const workflowNames = allWorkflows.map(w => w.name);
+    const hasCode = workflowNames.some(w => ['epcc', 'tdd'].includes(w));
+    const hasOffice = workflowNames.some(w => ['posts', 'slides'].includes(w));
+    const hasArchitecture = workflowNames.some(w =>
+      ['adr', 'big-bang-conversion'].includes(w)
+    );
+
+    expect(hasCode).toBe(true);
+    expect(hasOffice).toBe(true);
+    expect(hasArchitecture).toBe(false);
+  });
+
+  it('getAllAvailableWorkflows() should include all known domains by default', () => {
+    delete process.env['WORKFLOW_DOMAINS'];
+    delete process.env['VIBE_WORKFLOW_DOMAINS'];
+    delete process.env['DEFAULT_DOMAINS'];
+    delete process.env['DEFAULT_ALL_DOMAINS'];
+
+    const manager = new WorkflowManager();
+    const allWorkflows = manager.getAllAvailableWorkflows();
+
+    const domains = new Set(
+      allWorkflows.map(w => w.metadata?.domain).filter(Boolean) as string[]
+    );
+
+    // Should include all 7 known domains
+    expect(domains).toContain('code');
+    expect(domains).toContain('architecture');
+    expect(domains).toContain('office');
+    expect(domains).toContain('sdd');
   });
 });

--- a/packages/core/test/unit/workflow-domains-precedence.test.ts
+++ b/packages/core/test/unit/workflow-domains-precedence.test.ts
@@ -170,7 +170,7 @@ describe('WORKFLOW_DOMAINS precedence (backward compat)', () => {
     expect(hasArchitecture).toBe(false);
   });
 
-  it('should load all workflows when no domain configuration is set (empty Set fallback)', () => {
+  it('should load only code workflows when no domain configuration is set (default: code)', () => {
     delete process.env['WORKFLOW_DOMAINS'];
     delete process.env['VIBE_WORKFLOW_DOMAINS'];
     delete process.env['DEFAULT_DOMAINS'];
@@ -178,13 +178,17 @@ describe('WORKFLOW_DOMAINS precedence (backward compat)', () => {
     const manager = new WorkflowManager();
     const workflows = manager.getAvailableWorkflows();
 
-    // Collect all unique domains from loaded workflows
-    const domains = new Set(
-      workflows.map(w => w.metadata?.domain).filter(Boolean) as string[]
+    // Default is 'code' — should only include code domain workflows
+    const workflowNames = workflows.map(w => w.name);
+    const hasCode = workflowNames.some(w =>
+      ['epcc', 'tdd', 'bugfix', 'minor'].includes(w)
+    );
+    const hasArchitecture = workflowNames.some(w =>
+      ['adr', 'big-bang-conversion'].includes(w)
     );
 
-    // Should have workflows from multiple domains, not just 'code'
-    expect(domains.size).toBeGreaterThan(1);
+    expect(hasCode).toBe(true);
+    expect(hasArchitecture).toBe(false);
   });
 
   it('should use DEFAULT_ALL_DOMAINS env var in getAllAvailableWorkflows()', () => {

--- a/packages/mcp-server/src/server-config.ts
+++ b/packages/mcp-server/src/server-config.ts
@@ -19,6 +19,7 @@ import { TransitionEngine } from '@codemcp/workflows-core';
 import { InteractionLogger } from '@codemcp/workflows-core';
 import { WorkflowManager } from '@codemcp/workflows-core';
 import { TemplateManager } from '@codemcp/workflows-core';
+import { DOMAIN_DESCRIPTIONS } from '@codemcp/workflows-core';
 import {
   createLogger,
   setLoggingLevelFromString,
@@ -474,21 +475,22 @@ export async function registerMcpTools(
     'load_workflows',
     {
       description:
-        'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains.',
+        'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains. Use the domain-info:// resource to discover available domains and their descriptions.',
       inputSchema: {
         domains: z
-          .string()
+          .array(
+            z.enum([
+              'code' as const,
+              'architecture' as const,
+              'sdd' as const,
+              'sdd-crowd' as const,
+              'skilled' as const,
+              'office' as const,
+              'children' as const,
+            ])
+          )
           .describe(
-            'Comma-separated domain names to load. Replaces the current domain set.\n\n' +
-              'Available domains:\n' +
-              '  - code: Day-to-day software engineering (features, TDD, bugfixes, greenfield, code reviews, structured development)\n' +
-              '  - architecture: System understanding and planning (architectural decisions, legacy modernization, capability modeling, boundary analysis)\n' +
-              '  - sdd: Specification-driven development — write detailed specs before coding\n' +
-              '  - sdd-crowd: Multi-agent collaborative SDD with role-based handoffs (analyst, architect, developer)\n' +
-              '  - skilled: Skill-augmented development — explicit prompts to apply expertise (architecture, coding, testing)\n' +
-              '  - office: Content creation and communication (blog posts, slide presentations)\n' +
-              '  - children: Educational game development for ages 8-12\n\n' +
-              'Examples: "code", "code,architecture", "architecture,office"'
+            'Domain names to load. Use domain-info:// resource to discover available domains.'
           ),
       },
       annotations: {
@@ -703,6 +705,35 @@ export function registerMcpResources(
 
       const result = await handler.handle(new URL(uri.href), context);
       return responseRenderer.renderResourceResponse(result);
+    }
+  );
+
+  // Domain info resource — exposes all available domains with descriptions
+  mcpServer.resource(
+    'Available Domains',
+    'domain-info://',
+    {
+      description:
+        'List of all available workflow domains with descriptions. Use this resource before calling load_workflows to discover which domains are available and what each domain is suitable for.',
+      mimeType: 'application/json',
+    },
+    async () => {
+      const domains = Object.entries(DOMAIN_DESCRIPTIONS).map(
+        ([domain, description]) => ({
+          domain,
+          description,
+        })
+      );
+
+      return {
+        contents: [
+          {
+            uri: 'domain-info://',
+            mimeType: 'application/json',
+            text: JSON.stringify(domains, null, 2),
+          },
+        ],
+      };
     }
   );
 

--- a/packages/mcp-server/src/server-config.ts
+++ b/packages/mcp-server/src/server-config.ts
@@ -19,7 +19,10 @@ import { TransitionEngine } from '@codemcp/workflows-core';
 import { InteractionLogger } from '@codemcp/workflows-core';
 import { WorkflowManager } from '@codemcp/workflows-core';
 import { TemplateManager } from '@codemcp/workflows-core';
-import { DOMAIN_DESCRIPTIONS } from '@codemcp/workflows-core';
+import {
+  DOMAIN_DESCRIPTIONS,
+  KNOWN_DOMAIN_NAMES,
+} from '@codemcp/workflows-core';
 import {
   createLogger,
   setLoggingLevelFromString,
@@ -478,17 +481,7 @@ export async function registerMcpTools(
         'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains. Use the domain:// resource to discover available domains and their descriptions.',
       inputSchema: {
         domains: z
-          .array(
-            z.enum([
-              'code' as const,
-              'architecture' as const,
-              'sdd' as const,
-              'sdd-crowd' as const,
-              'skilled' as const,
-              'office' as const,
-              'children' as const,
-            ])
-          )
+          .array(z.enum(KNOWN_DOMAIN_NAMES))
           .describe(
             'Domain names to load. Use domain:// resource to discover available domains.'
           ),

--- a/packages/mcp-server/src/server-config.ts
+++ b/packages/mcp-server/src/server-config.ts
@@ -469,6 +469,39 @@ export async function registerMcpTools(
     createToolHandler('list_workflows', toolRegistry, responseRenderer, context)
   );
 
+  // Register load_workflows tool — allows LLM to dynamically load domains
+  mcpServer.registerTool(
+    'load_workflows',
+    {
+      description:
+        'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains.',
+      inputSchema: {
+        domains: z
+          .string()
+          .describe(
+            'Comma-separated domain names to load. Replaces the current domain set.\n\n' +
+              'Available domains:\n' +
+              '  - code: Day-to-day software engineering (features, TDD, bugfixes, greenfield, code reviews, structured development)\n' +
+              '  - architecture: System understanding and planning (architectural decisions, legacy modernization, capability modeling, boundary analysis)\n' +
+              '  - sdd: Specification-driven development — write detailed specs before coding\n' +
+              '  - sdd-crowd: Multi-agent collaborative SDD with role-based handoffs (analyst, architect, developer)\n' +
+              '  - skilled: Skill-augmented development — explicit prompts to apply expertise (architecture, coding, testing)\n' +
+              '  - office: Content creation and communication (blog posts, slide presentations)\n' +
+              '  - children: Educational game development for ages 8-12\n\n' +
+              'Examples: "code", "code,architecture", "architecture,office"'
+          ),
+      },
+      annotations: {
+        title: 'Workflow Domain Loader',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    createToolHandler('load_workflows', toolRegistry, responseRenderer, context)
+  );
+
   // Register get_tool_info tool
   mcpServer.registerTool(
     'get_tool_info',

--- a/packages/mcp-server/src/server-config.ts
+++ b/packages/mcp-server/src/server-config.ts
@@ -475,7 +475,7 @@ export async function registerMcpTools(
     'load_workflows',
     {
       description:
-        'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains. Use the domain-info:// resource to discover available domains and their descriptions.',
+        'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains. Use the domain:// resource to discover available domains and their descriptions.',
       inputSchema: {
         domains: z
           .array(
@@ -490,7 +490,7 @@ export async function registerMcpTools(
             ])
           )
           .describe(
-            'Domain names to load. Use domain-info:// resource to discover available domains.'
+            'Domain names to load. Use domain:// resource to discover available domains.'
           ),
       },
       annotations: {
@@ -711,7 +711,7 @@ export function registerMcpResources(
   // Domain info resource — exposes all available domains with descriptions
   mcpServer.resource(
     'Available Domains',
-    'domain-info://',
+    'domain://',
     {
       description:
         'List of all available workflow domains with descriptions. Use this resource before calling load_workflows to discover which domains are available and what each domain is suitable for.',
@@ -728,7 +728,7 @@ export function registerMcpResources(
       return {
         contents: [
           {
-            uri: 'domain-info://',
+            uri: 'domain://',
             mimeType: 'application/json',
             text: JSON.stringify(domains, null, 2),
           },

--- a/packages/mcp-server/src/tool-handlers/index.ts
+++ b/packages/mcp-server/src/tool-handlers/index.ts
@@ -17,6 +17,7 @@ import { ListWorkflowsHandler } from './list-workflows.js';
 import { GetToolInfoHandler } from './get-tool-info.js';
 import { SetupProjectDocsHandler } from './setup-project-docs.js';
 import { NoIdeaHandler } from './no-idea.js';
+import { LoadWorkflowsHandler } from './load-workflows.js';
 import { ToolHandler, ToolRegistry } from '../types.js';
 
 const logger = createLogger('ToolRegistry');
@@ -58,6 +59,7 @@ export function createToolRegistry(): ToolRegistry {
   registry.register('resume_workflow', new ResumeWorkflowHandler());
   registry.register('reset_development', new ResetDevelopmentHandler());
   registry.register('list_workflows', new ListWorkflowsHandler());
+  registry.register('load_workflows', new LoadWorkflowsHandler());
   registry.register('get_tool_info', new GetToolInfoHandler());
   registry.register('setup_project_docs', new SetupProjectDocsHandler());
   registry.register('no_idea', new NoIdeaHandler());
@@ -77,6 +79,7 @@ export { StartDevelopmentHandler } from './start-development.js';
 export { ResumeWorkflowHandler } from './resume-workflow.js';
 export { ResetDevelopmentHandler } from './reset-development.js';
 export { ListWorkflowsHandler } from './list-workflows.js';
+export { LoadWorkflowsHandler } from './load-workflows.js';
 export { GetToolInfoHandler } from './get-tool-info.js';
 export { SetupProjectDocsHandler } from './setup-project-docs.js';
 export { NoIdeaHandler } from './no-idea.js';

--- a/packages/mcp-server/src/tool-handlers/load-workflows.ts
+++ b/packages/mcp-server/src/tool-handlers/load-workflows.ts
@@ -9,32 +9,21 @@
 
 import { z } from 'zod';
 import { BaseToolHandler } from './base-tool-handler.js';
-import { createLogger, DOMAIN_DESCRIPTIONS } from '@codemcp/workflows-core';
+import { createLogger } from '@codemcp/workflows-core';
 import { ServerContext } from '../types.js';
 
 const logger = createLogger('LoadWorkflowsHandler');
 
 /**
- * Domain descriptions for tool parameter metadata.
- * Exposed to the LLM via the tool's parameter description.
- */
-const DOMAIN_DESCRIPTION_TEXT = Object.entries(DOMAIN_DESCRIPTIONS)
-  .map(([domain, description]) => `  - ${domain}: ${description}`)
-  .join('\n');
-
-/**
- * Schema for load_workflows tool arguments
+ * Schema for load_workflows tool arguments.
+ * Domains are passed as an array of strings for type safety.
  */
 const LoadWorkflowsArgsSchema = z.object({
-  domains: z.string().describe(
-    `Comma-separated domain names to load. Replaces the current domain set.
-
-Available domains:
-${DOMAIN_DESCRIPTION_TEXT}
-
-Examples: "code", "code,architecture", "architecture,office"
-`
-  ),
+  domains: z
+    .array(z.string())
+    .describe(
+      'Domain names to load. Use domain-info:// resource to discover available domains and their descriptions.'
+    ),
 });
 
 type LoadWorkflowsArgs = z.infer<typeof LoadWorkflowsArgsSchema>;
@@ -73,21 +62,16 @@ export class LoadWorkflowsHandler extends BaseToolHandler<
       const totalWorkflows =
         context.workflowManager.getAvailableWorkflows().length;
 
-      const domains = args.domains
-        .split(',')
-        .map(d => d.trim())
-        .filter(d => d);
-
       logger.info('Workflows loaded successfully', {
-        domains,
+        domains: args.domains,
         totalWorkflows,
       });
 
       return {
         success: true,
-        domains,
+        domains: args.domains,
         totalWorkflows,
-        message: `Loaded workflows from domains: ${domains.join(', ')}. Total workflows available: ${totalWorkflows}.`,
+        message: `Loaded workflows from domains: ${args.domains.join(', ')}. Total workflows available: ${totalWorkflows}.`,
       };
     } catch (error) {
       const errorMessage =

--- a/packages/mcp-server/src/tool-handlers/load-workflows.ts
+++ b/packages/mcp-server/src/tool-handlers/load-workflows.ts
@@ -22,7 +22,7 @@ const LoadWorkflowsArgsSchema = z.object({
   domains: z
     .array(z.string())
     .describe(
-      'Domain names to load. Use domain-info:// resource to discover available domains and their descriptions.'
+      'Domain names to load. Use domain:// resource to discover available domains and their descriptions.'
     ),
 });
 

--- a/packages/mcp-server/src/tool-handlers/load-workflows.ts
+++ b/packages/mcp-server/src/tool-handlers/load-workflows.ts
@@ -1,0 +1,107 @@
+/**
+ * Load Workflows Tool Handler
+ *
+ * Allows the LLM to dynamically load workflows from one or more domains
+ * at runtime. This is essential for long-lived processes (MCP server,
+ * OpenCode plugin) where the initial domain configuration may not include
+ * all needed workflows.
+ */
+
+import { z } from 'zod';
+import { BaseToolHandler } from './base-tool-handler.js';
+import { createLogger, DOMAIN_DESCRIPTIONS } from '@codemcp/workflows-core';
+import { ServerContext } from '../types.js';
+
+const logger = createLogger('LoadWorkflowsHandler');
+
+/**
+ * Domain descriptions for tool parameter metadata.
+ * Exposed to the LLM via the tool's parameter description.
+ */
+const DOMAIN_DESCRIPTION_TEXT = Object.entries(DOMAIN_DESCRIPTIONS)
+  .map(([domain, description]) => `  - ${domain}: ${description}`)
+  .join('\n');
+
+/**
+ * Schema for load_workflows tool arguments
+ */
+const LoadWorkflowsArgsSchema = z.object({
+  domains: z.string().describe(
+    `Comma-separated domain names to load. Replaces the current domain set.
+
+Available domains:
+${DOMAIN_DESCRIPTION_TEXT}
+
+Examples: "code", "code,architecture", "architecture,office"
+`
+  ),
+});
+
+type LoadWorkflowsArgs = z.infer<typeof LoadWorkflowsArgsSchema>;
+
+/**
+ * Response format for load_workflows tool
+ */
+interface LoadWorkflowsResponse {
+  success: boolean;
+  domains: string[];
+  totalWorkflows: number;
+  message: string;
+}
+
+/**
+ * Tool handler for loading workflows from specified domains
+ */
+export class LoadWorkflowsHandler extends BaseToolHandler<
+  LoadWorkflowsArgs,
+  LoadWorkflowsResponse
+> {
+  protected readonly argsSchema = LoadWorkflowsArgsSchema;
+
+  async executeHandler(
+    args: LoadWorkflowsArgs,
+    context: ServerContext
+  ): Promise<LoadWorkflowsResponse> {
+    logger.info('Loading workflows from domains', {
+      domains: args.domains,
+      projectPath: context.projectPath,
+    });
+
+    try {
+      context.workflowManager.setDomains(args.domains);
+
+      const totalWorkflows =
+        context.workflowManager.getAvailableWorkflows().length;
+
+      const domains = args.domains
+        .split(',')
+        .map(d => d.trim())
+        .filter(d => d);
+
+      logger.info('Workflows loaded successfully', {
+        domains,
+        totalWorkflows,
+      });
+
+      return {
+        success: true,
+        domains,
+        totalWorkflows,
+        message: `Loaded workflows from domains: ${domains.join(', ')}. Total workflows available: ${totalWorkflows}.`,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      logger.error('Failed to load workflows', error as Error, {
+        domains: args.domains,
+      });
+
+      return {
+        success: false,
+        domains: [],
+        totalWorkflows: 0,
+        message: `Failed to load workflows: ${errorMessage}`,
+      };
+    }
+  }
+}

--- a/packages/opencode-plugin/src/plugin.ts
+++ b/packages/opencode-plugin/src/plugin.ts
@@ -19,6 +19,7 @@ import { createConductReviewTool } from './tool-handlers/conduct-review.js';
 import { createResetDevelopmentTool } from './tool-handlers/reset-development.js';
 import { createStartDevelopmentTool } from './tool-handlers/start-development.js';
 import { createSetupProjectDocsTool } from './tool-handlers/setup-project-docs.js';
+import { createLoadWorkflowsTool } from './tool-handlers/load-workflows.js';
 import {
   createOpenCodeLogger,
   createOpenCodeLoggerFactory,
@@ -794,6 +795,10 @@ ACTION REQUIRED: Use proceed_to_phase tool to move to a phase that allows editin
         setup_project_docs: wrap(
           'setup_project_docs',
           await createSetupProjectDocsTool(input.directory, getServerContext)
+        ),
+        load_workflows: wrap(
+          'load_workflows',
+          createLoadWorkflowsTool(getServerContext)
         ),
       };
     })(),

--- a/packages/opencode-plugin/src/tool-handlers/load-workflows.ts
+++ b/packages/opencode-plugin/src/tool-handlers/load-workflows.ts
@@ -1,28 +1,23 @@
 import { z } from 'zod';
-import type { ToolDefinition, ServerContext } from '../types.js';
+import type { ToolDefinition } from '../types.js';
+import type { ServerContext } from '@codemcp/workflows-server';
 import { tool } from './tool-helper.js';
 import { createLogger } from '@codemcp/workflows-core';
 
 const logger = createLogger('LoadWorkflowsHandler');
 
 /**
- * Domain descriptions for tool parameter metadata.
- * Exposed to the LLM via the tool's parameter description.
- * Short summaries for inline tool parameter use.
+ * Known domain names — kept in sync with DOMAIN_DESCRIPTIONS in core.
  */
-const SHORT_DOMAIN_DESCRIPTIONS: Record<string, string> = {
-  code: 'Day-to-day software engineering (features, TDD, bugfixes, greenfield, code reviews)',
-  architecture:
-    'System understanding and planning (architectural decisions, legacy modernization, capability modeling)',
-  sdd: 'Specification-driven development — write detailed specs before coding',
-  'sdd-crowd':
-    'Multi-agent collaborative SDD with role-based handoffs (analyst, architect, developer)',
-  skilled:
-    'Skill-augmented development — explicit prompts to apply expertise (architecture, coding, testing)',
-  office:
-    'Content creation and communication (blog posts, slide presentations)',
-  children: 'Educational game development for ages 8-12',
-};
+const KNOWN_DOMAINS = [
+  'code',
+  'architecture',
+  'sdd',
+  'sdd-crowd',
+  'skilled',
+  'office',
+  'children',
+] as const;
 
 /**
  * Create the load_workflows tool for the OpenCode plugin.
@@ -31,21 +26,14 @@ const SHORT_DOMAIN_DESCRIPTIONS: Record<string, string> = {
 export function createLoadWorkflowsTool(
   getServerContext: () => Promise<ServerContext>
 ): ToolDefinition {
-  const domainText = Object.entries(SHORT_DOMAIN_DESCRIPTIONS)
-    .map(([domain, description]) => `  - ${domain}: ${description}`)
-    .join('\n');
-
   return tool({
     description:
-      'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains.',
+      'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains. Available domains: code, architecture, sdd, sdd-crowd, skilled, office, children.',
     args: {
       domains: z
-        .string()
+        .array(z.enum(KNOWN_DOMAINS))
         .describe(
-          `Comma-separated domain names to load. Replaces the current domain set.\n\n` +
-            `Available domains:\n` +
-            `${domainText}\n\n` +
-            `Examples: "code", "code,architecture", "architecture,office"`
+          'Domain names to load. Available domains: code, architecture, sdd, sdd-crowd, skilled, office, children.'
         ),
     },
     execute: async args => {
@@ -57,24 +45,19 @@ export function createLoadWorkflowsTool(
         const serverContext = await getServerContext();
         serverContext.workflowManager.setDomains(args.domains);
 
-        const domains = args.domains
-          .split(',')
-          .map(d => d.trim())
-          .filter(d => d);
-
         const totalWorkflows =
           serverContext.workflowManager.getAvailableWorkflows().length;
 
         logger.info('Workflows loaded successfully', {
-          domains,
+          domains: args.domains,
           totalWorkflows,
         });
 
         return JSON.stringify({
           success: true,
-          domains,
+          domains: args.domains,
           totalWorkflows,
-          message: `Loaded workflows from domains: ${domains.join(', ')}. Total workflows available: ${totalWorkflows}.`,
+          message: `Loaded workflows from domains: ${args.domains.join(', ')}. Total workflows available: ${totalWorkflows}.`,
         });
       } catch (error) {
         const errorMessage =

--- a/packages/opencode-plugin/src/tool-handlers/load-workflows.ts
+++ b/packages/opencode-plugin/src/tool-handlers/load-workflows.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+import type { ToolDefinition, ServerContext } from '../types.js';
+import { tool } from './tool-helper.js';
+import { createLogger } from '@codemcp/workflows-core';
+
+const logger = createLogger('LoadWorkflowsHandler');
+
+/**
+ * Domain descriptions for tool parameter metadata.
+ * Exposed to the LLM via the tool's parameter description.
+ * Short summaries for inline tool parameter use.
+ */
+const SHORT_DOMAIN_DESCRIPTIONS: Record<string, string> = {
+  code: 'Day-to-day software engineering (features, TDD, bugfixes, greenfield, code reviews)',
+  architecture:
+    'System understanding and planning (architectural decisions, legacy modernization, capability modeling)',
+  sdd: 'Specification-driven development — write detailed specs before coding',
+  'sdd-crowd':
+    'Multi-agent collaborative SDD with role-based handoffs (analyst, architect, developer)',
+  skilled:
+    'Skill-augmented development — explicit prompts to apply expertise (architecture, coding, testing)',
+  office:
+    'Content creation and communication (blog posts, slide presentations)',
+  children: 'Educational game development for ages 8-12',
+};
+
+/**
+ * Create the load_workflows tool for the OpenCode plugin.
+ * Allows the LLM to dynamically load workflows from one or more domains.
+ */
+export function createLoadWorkflowsTool(
+  getServerContext: () => Promise<ServerContext>
+): ToolDefinition {
+  const domainText = Object.entries(SHORT_DOMAIN_DESCRIPTIONS)
+    .map(([domain, description]) => `  - ${domain}: ${description}`)
+    .join('\n');
+
+  return tool({
+    description:
+      'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains.',
+    args: {
+      domains: z
+        .string()
+        .describe(
+          `Comma-separated domain names to load. Replaces the current domain set.\n\n` +
+            `Available domains:\n` +
+            `${domainText}\n\n` +
+            `Examples: "code", "code,architecture", "architecture,office"`
+        ),
+    },
+    execute: async args => {
+      logger.info('Loading workflows from domains', {
+        domains: args.domains,
+      });
+
+      try {
+        const serverContext = await getServerContext();
+        serverContext.workflowManager.setDomains(args.domains);
+
+        const domains = args.domains
+          .split(',')
+          .map(d => d.trim())
+          .filter(d => d);
+
+        const totalWorkflows =
+          serverContext.workflowManager.getAvailableWorkflows().length;
+
+        logger.info('Workflows loaded successfully', {
+          domains,
+          totalWorkflows,
+        });
+
+        return JSON.stringify({
+          success: true,
+          domains,
+          totalWorkflows,
+          message: `Loaded workflows from domains: ${domains.join(', ')}. Total workflows available: ${totalWorkflows}.`,
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        logger.error('Failed to load workflows', error as Error, {
+          domains: args.domains,
+        });
+
+        return JSON.stringify({
+          success: false,
+          domains: [],
+          totalWorkflows: 0,
+          message: `Failed to load workflows: ${errorMessage}`,
+        });
+      }
+    },
+  });
+}

--- a/packages/opencode-plugin/src/tool-handlers/load-workflows.ts
+++ b/packages/opencode-plugin/src/tool-handlers/load-workflows.ts
@@ -2,22 +2,9 @@ import { z } from 'zod';
 import type { ToolDefinition } from '../types.js';
 import type { ServerContext } from '@codemcp/workflows-server';
 import { tool } from './tool-helper.js';
-import { createLogger } from '@codemcp/workflows-core';
+import { createLogger, KNOWN_DOMAIN_NAMES } from '@codemcp/workflows-core';
 
 const logger = createLogger('LoadWorkflowsHandler');
-
-/**
- * Known domain names — kept in sync with DOMAIN_DESCRIPTIONS in core.
- */
-const KNOWN_DOMAINS = [
-  'code',
-  'architecture',
-  'sdd',
-  'sdd-crowd',
-  'skilled',
-  'office',
-  'children',
-] as const;
 
 /**
  * Create the load_workflows tool for the OpenCode plugin.
@@ -31,7 +18,7 @@ export function createLoadWorkflowsTool(
       'Load workflows from one or more domains. Replaces the current domain set with the specified domains. Use this tool when you need to access workflows from a domain that is not currently loaded. The tool will reload all workflows for the specified domains. Available domains: code, architecture, sdd, sdd-crowd, skilled, office, children.',
     args: {
       domains: z
-        .array(z.enum(KNOWN_DOMAINS))
+        .array(z.enum(KNOWN_DOMAIN_NAMES))
         .describe(
           'Domain names to load. Available domains: code, architecture, sdd, sdd-crowd, skilled, office, children.'
         ),


### PR DESCRIPTION
## Summary

Eliminate hardcoded `'code'` default domain in `WorkflowManager` and provide runtime domain switching for long-lived processes (MCP server, OpenCode plugin).

### Changes
- **Four-level env var chain**: constructor param > `WORKFLOW_DOMAINS` > `DEFAULT_DOMAINS` > `VIBE_WORKFLOW_DOMAINS` > `code` (default)
- **`defaultDomains` constructor parameter** for programmatic override (library consumers, testing)
- **`DEFAULT_ALL_DOMAINS` env var** for `getAllAvailableWorkflows()` — replaces incomplete hardcoded list
- **`setDomains()` method** for runtime domain switching with validation against known domains
- **`DOMAIN_DESCRIPTIONS` constant** with meaningful summaries of what each domain is suitable for
- **`KNOWN_DOMAIN_NAMES` constant** — single source of truth for domain names, exported from core
- **`load_workflows` tool** — simple enum parameter, domain descriptions exposed via `domain://` resource
- **`domain://` resource** — exposes all available domains with descriptions for LLM discovery
- **Bug fix**: `loadPredefinedWorkflows()` now clears maps before reloading (prevents workflow accumulation)

### Tests
- 18 new tests: 9 for env var precedence chain, 9 for `setDomains()`
- All 401 tests pass (previously failing `game-beginner.yaml` test now passes)

### Architecture Decision
Domain descriptions are exposed as a **resource** (`domain://`) rather than embedded in the tool parameter. This keeps the tool schema lean and reduces LLM context usage. The LLM can query the resource to discover domains before calling `load_workflows`.

### Affected Files
- `packages/core/src/workflow-manager.ts` — core changes
- `packages/core/test/unit/workflow-domains-precedence.test.ts` — 9 new tests
- `packages/core/test/unit/workflow-domain-switching.test.ts` — 9 new tests (new file)
- `packages/core/test/unit/workflow-domain-filtering.test.ts` — updated for `code`-only default
- `packages/mcp-server/src/server-config.ts` — register `load_workflows` tool + `domain://` resource
- `packages/mcp-server/src/tool-handlers/load-workflows.ts` — simplified handler (new file)
- `packages/mcp-server/src/tool-handlers/index.ts` — register handler
- `packages/opencode-plugin/src/plugin.ts` — register `load_workflows` tool
- `packages/opencode-plugin/src/tool-handlers/load-workflows.ts` — simplified handler (new file)

### Backward Compatibility
- `VIBE_WORKFLOW_DOMAINS` still works as lowest-priority env var
- Adding `options?: WorkflowManagerOptions` to constructor is backward compatible
- Default remains `code` — out-of-the-box behavior unchanged